### PR TITLE
Expose traversal method independently from middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,34 +1,13 @@
 'use strict';
 
 var _ = require('underscore'),
-    fs = require('fs'),
-    path = require('path');
+    traverse = require('./lib/traverse');
 
-module.exports = function (app) {
+var Parser = function (app) {
 
     var ext = '.' + app.get('view engine');
-    var regexp = new RegExp(ext + '$');
 
-    function parseDir(partials, dir, prefix) {
-        var files = fs.readdirSync(dir);
-        prefix = prefix || '';
-
-        _.each(files, function (file) {
-            var stat = fs.statSync(path.join(dir, file)),
-                pathName,
-                partialName;
-            if (stat.isDirectory()) {
-                parseDir(partials, path.join(dir, file), prefix + '/' + file);
-            } else if (file.match(regexp)) {
-                pathName = (prefix + '/' + file).replace(/^\//, '');
-                partialName = pathName.replace(/\//g, '-').replace(regexp, '');
-                partials[partialName] = pathName;
-            }
-        });
-        return partials;
-    }
-
-    var partials = parseDir({}, app.get('views'));
+    var partials = traverse(app.get('views'));
 
     return function (req, res, next) {
         res.locals.partials = res.locals.partials || {};
@@ -36,3 +15,7 @@ module.exports = function (app) {
         next();
     };
 };
+
+Parser.traverse = traverse;
+
+module.exports = Parser;

--- a/lib/traverse.js
+++ b/lib/traverse.js
@@ -1,0 +1,30 @@
+var fs = require('fs'),
+    path = require('path');
+
+module.exports = function (root, ext) {
+
+    ext = ext || '.html';
+    var regexp = new RegExp(ext + '$');
+
+    function parseDir(partials, dir, prefix) {
+        var files = fs.readdirSync(dir);
+        prefix = prefix || '';
+
+        files.forEach(function (file) {
+            var stat = fs.statSync(path.join(dir, file)),
+                pathName,
+                partialName;
+            if (stat.isDirectory()) {
+                parseDir(partials, path.join(dir, file), prefix + '/' + file);
+            } else if (file.match(regexp)) {
+                pathName = (prefix + '/' + file).replace(/^\//, '');
+                partialName = pathName.replace(/\//g, '-').replace(regexp, '');
+                partials[partialName] = pathName;
+            }
+        });
+        return partials;
+    }
+
+    return parseDir({}, root);
+
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-partial-templates",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A middleware that will use the views path to create a partials key-value object that makes the file paths of partial templates acessible on the locals property of an HTTP response.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In some cases we may wish to get a list of templates in a directory independently of the the express app/request/response cycle. For example, the build script I'm currently writing to compile static error page html for PEX.

TODO/TOCONSIDER - find a module which does the tree traversal.
