### PR TITLE
Add prefix option to namespace partial templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "iojs"
+notifications:
+  email: false

--- a/index.js
+++ b/index.js
@@ -3,10 +3,12 @@
 var _ = require('underscore'),
     traverse = require('./lib/traverse');
 
-var Parser = function (app) {
+var Parser = function (app, options) {
+
+    options = options || {};
 
     var ext = '.' + app.get('view engine'),
-        partials = traverse(app.get('views'), ext);
+        partials = traverse(app.get('views'), ext, options.prefix);
 
     return function (req, res, next) {
         res.locals.partials = res.locals.partials || {};

--- a/lib/traverse.js
+++ b/lib/traverse.js
@@ -2,19 +2,26 @@ var fs = require('fs-tree-traverse'),
     _ = require('underscore'),
     path = require('path');
 
-module.exports = function (root, ext) {
+module.exports = function (root, ext, prefix) {
 
     ext = ext || '.html';
+    prefix = prefix || '';
+
+    if (prefix && prefix.substr(-1) !== '-') {
+        prefix += '-';
+    }
+
     var regexp = new RegExp(ext + '$');
 
-    var files = fs.listSync(root, { relative: true });
+    var files = fs.listSync(root);
 
     var response = {};
     _.chain(files)
         .filter(function (file) { return file.match(regexp); })
-        .map(function (file) { return file.replace(regexp, '').replace(/^\.\//, ''); })
+        .map(function (file) { return file.replace(regexp, ''); })
         .each(function (file) {
-            response[file.replace(/\//g, '-')] = file;
+            var name = path.relative(root, file).split(path.sep).join('-');
+            response[prefix + name] = file;
         });
     return response;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-partial-templates",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "A middleware that will use the views path to create a partials key-value object that makes the file paths of partial templates acessible on the locals property of an HTTP response.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A middleware that will use the views path to create a partials key-value object that makes the file paths of partial templates acessible on the locals property of an HTTP response.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha ./test --require ./test/helper"
   },
   "repository": {
     "type": "git",
@@ -26,5 +26,11 @@
   "dependencies": {
     "fs-tree-traverse": "0.1.0",
     "underscore": "^1.7.0"
+  },
+  "devDependencies": {
+    "chai": "^2.1.1",
+    "mocha": "^2.2.1",
+    "sinon": "^1.13.0",
+    "sinon-chai": "^2.7.0"
   }
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,7 @@
+var chai = require('chai');
+
+global.should = chai.should();
+global.expect = chai.expect();
+global.sinon = require('sinon');
+
+chai.use(require('sinon-chai'));

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1,0 +1,61 @@
+var partials = require('../');
+
+var traverse = require('fs-tree-traverse');
+
+describe('partial-templates', function () {
+
+    var app, req, res, next,
+        files = [
+            '/usr/test/layout.html',
+            '/usr/test/partials/a.html',
+            '/usr/test/partials/b.html',
+            '/usr/test/partials/image.jpeg'
+        ];
+
+    beforeEach(function () {
+        app = {
+            get: sinon.stub()
+        };
+        app.get.withArgs('view engine').returns('html');
+        app.get.withArgs('views').returns('/usr/test');
+        sinon.stub(traverse, 'listSync').returns(files);
+    });
+    afterEach(function () {
+        traverse.listSync.restore();
+    });
+
+    it('returns a middleware function', function () {
+        partials(app).should.be.a('function');
+        partials(app).length.should.equal(3);
+    });
+
+    describe('middleware', function () {
+
+        beforeEach(function () {
+            res = {
+                locals: {}
+            };
+            next = sinon.stub();
+        });
+
+        it('adds partial templates to res.locals', function () {
+            partials(app)(req, res, next);
+            res.locals.partials.should.eql({
+                layout: '/usr/test/layout',
+                'partials-a': '/usr/test/partials/a',
+                'partials-b': '/usr/test/partials/b'
+            });
+        });
+
+        it('allows for an optional prefix', function () {
+            partials(app, { prefix: 'foo' })(req, res, next);
+            res.locals.partials.should.eql({
+                'foo-layout': '/usr/test/layout',
+                'foo-partials-a': '/usr/test/partials/a',
+                'foo-partials-b': '/usr/test/partials/b'
+            });
+        });
+
+    });
+
+});

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -38,6 +38,19 @@ describe('partial-templates', function () {
             next = sinon.stub();
         });
 
+        it('does not overwrite existing partials', function () {
+            res.locals.partials = {
+                here: 'already'
+            };
+            partials(app)(req, res, next);
+            res.locals.partials.should.eql({
+                here: 'already',
+                layout: '/usr/test/layout',
+                'partials-a': '/usr/test/partials/a',
+                'partials-b': '/usr/test/partials/b'
+            });
+        });
+
         it('adds partial templates to res.locals', function () {
             partials(app)(req, res, next);
             res.locals.partials.should.eql({


### PR DESCRIPTION
To allow sets of partials defined by submodules to namespace themselves without need for messy directory structures and this avoid naming conflicts.
